### PR TITLE
use_origin_to_point_instead_of_ray_direction_for_color_query.

### DIFF
--- a/config/tat_truck_every_8_test.yaml
+++ b/config/tat_truck_every_8_test.yaml
@@ -40,7 +40,7 @@ rasterisation-config:
   depth-to-sort-key-scale: 10.0
   far-plane: 2000.0
   near-plane: 0.4
-summary-writer-log-dir: logs/tat_truck_every_8_experiment_direction_of_point
+summary-writer-log-dir: logs/tat_truck_every_8_experiment_direction_instead_of_ray
 train-dataset-json-path: 'data/tat_truck_every_8_test/train.json'
 val-dataset-json-path: 'data/tat_truck_every_8_test/val.json'
 val-interval: 1000


### PR DESCRIPTION
Once we prove that this doesn't matter, we can optimize our code by block shared memory.