### PR TITLE
using block shared memory in backward, tested, and it is much faster

### DIFF
--- a/GaussianPointAdaptiveController.py
+++ b/GaussianPointAdaptiveController.py
@@ -181,7 +181,7 @@ class GaussianPointAdaptiveController:
         # point_features_in_camera = pointcloud_features[point_id_in_camera_list]
         will_be_remove_mask = floater_mask_in_camera | transparent_point_mask[point_id_in_camera_list]
         # shape: [num_points_in_camera, 2]
-        grad_viewspace = input_data.grad_viewspace
+        grad_viewspace = input_data.magnitude_grad_viewspace
         # shape: [num_points_in_camera, num_features]
         # all these three masks are on num_points_in_camera, not num_points
         to_densify_mask = (grad_viewspace.norm(

--- a/GaussianPointCloudRasterisation.py
+++ b/GaussianPointCloudRasterisation.py
@@ -628,6 +628,7 @@ def gaussian_point_rasterisation_backward(
                 
                 tile_point_alpha[thread_id] = to_load_gaussian_point_3d.alpha
                 tile_point_grad_alpha[thread_id] = 0.0
+                tile_point_num_affected_pixels[thread_id] = 0
                 
             ti.simt.block.sync()
             for inverse_point_offset_offset in range(256):

--- a/gaussian_point_train.py
+++ b/gaussian_point_train.py
@@ -259,10 +259,6 @@ class GaussianPointCloudTrainer:
             b_grad = feature_grad[:, 40:56]
             num_overlap_tiles = grad_input.num_overlap_tiles
             num_affected_pixels = grad_input.num_affected_pixels
-            magnitude_grad_color = grad_input.magnitude_grad_color
-            mean_magnitude_grad_color = magnitude_grad_color / num_affected_pixels
-            # fill nan with 0
-            mean_magnitude_grad_color[mean_magnitude_grad_color != mean_magnitude_grad_color] = 0
             writer.add_histogram("grad/xyz_grad", xyz_grad, iteration)
             writer.add_histogram("grad/uv_grad", uv_grad, iteration)
             writer.add_histogram("grad/q_grad", q_grad, iteration)
@@ -273,8 +269,6 @@ class GaussianPointCloudTrainer:
             writer.add_histogram("grad/b_grad", b_grad, iteration)
             writer.add_histogram("value/num_overlap_tiles", num_overlap_tiles, iteration)
             writer.add_histogram("value/num_affected_pixels", num_affected_pixels, iteration)
-            writer.add_histogram("value/magnitude_grad_color", magnitude_grad_color, iteration)
-            writer.add_histogram("value/mean_magnitude_grad_color", mean_magnitude_grad_color, iteration)
 
     @staticmethod
     def _plot_value_histogram(scene: GaussianPointCloudScene, writer, iteration):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-taichi>=1.5.0
+taichi>=1.6.0
 matplotlib
 numpy
 pytorch_msssim


### PR DESCRIPTION
As I just notice that taichi actually supports block shared memory, using block shared memory to preload data as the paper suggests shall be faster.
Also, I restructured the way to do backward, and the computation shall be reduced a lot.

The PR is still under developing/testing