### PR TITLE
Switch camera pose from SE3 to quaternion, also support multiple camera poses for later dynamic object.

### DIFF
--- a/taichi_3d_gaussian_splatting/GaussianPointAdaptiveController.py
+++ b/taichi_3d_gaussian_splatting/GaussianPointAdaptiveController.py
@@ -86,6 +86,7 @@ class GaussianPointAdaptiveController:
         pointcloud_features: torch.Tensor
         # shape: [num_points], dtype: int8 because taichi doesn't support bool type
         point_invalid_mask: torch.Tensor
+        point_object_id: torch.Tensor  # shape: [num_points]
 
     @dataclass
     class GaussianPointAdaptiveControllerDensifyPointInfo:
@@ -247,6 +248,8 @@ class GaussianPointAdaptiveController:
                 self.densify_point_info.densify_point_position_before_optimization[:num_fillable_densify_points]
             self.maintained_parameters.pointcloud_features[invalid_point_id_to_fill] = \
                 self.maintained_parameters.pointcloud_features[self.densify_point_info.densify_point_id[:num_fillable_densify_points]]
+            self.maintained_parameters.point_object_id[invalid_point_id_to_fill] = \
+                self.maintained_parameters.point_object_id[self.densify_point_info.densify_point_id[:num_fillable_densify_points]]
             self.maintained_parameters.pointcloud_features[invalid_point_id_to_fill, 4:7] -= \
                 self.densify_point_info.densify_size_reduction_factor[:num_fillable_densify_points]
             over_reconstructed_mask = (self.densify_point_info.densify_size_reduction_factor[:num_fillable_densify_points] > 1e-6).reshape(-1)

--- a/taichi_3d_gaussian_splatting/GaussianPointCloudRasterisation.py
+++ b/taichi_3d_gaussian_splatting/GaussianPointCloudRasterisation.py
@@ -4,13 +4,14 @@ from dataclasses import dataclass
 from .Camera import CameraInfo, CameraView
 from torch.cuda.amp import custom_bwd, custom_fwd
 from .utils import (torch_type, data_type, ti2torch, torch2ti,
-                   ti2torch_grad, torch2ti_grad,
-                   get_ray_origin_and_direction_by_uv,
-                   get_point_probability_density_from_2d_gaussian_normalized,
-                   grad_point_probability_density_2d_normalized,
-                   taichi_inverse_se3,
-                   inverse_se3)
-from .GaussianPoint3D import GaussianPoint3D, project_point_to_camera, rotation_matrix_from_quaternion
+                    ti2torch_grad, torch2ti_grad,
+                    get_ray_origin_and_direction_by_uv,
+                    get_point_probability_density_from_2d_gaussian_normalized,
+                    grad_point_probability_density_2d_normalized,
+                    taichi_inverse_se3,
+                    inverse_se3_qt_torch,
+                    inverse_se3)
+from .GaussianPoint3D import GaussianPoint3D, project_point_to_camera, rotation_matrix_from_quaternion, tranform_matrix_from_quaternion_and_translation
 from .SphericalHarmonics import SphericalHarmonics, vec16f
 from typing import List, Tuple, Optional, Callable, Union
 from dataclass_wizard import YAMLWizard
@@ -21,20 +22,21 @@ mat4x3f = ti.types.matrix(n=4, m=3, dtype=ti.f32)
 
 BOUNDARY_TILES = 3
 
+
 @ti.kernel
 def filter_point_in_camera(
     pointcloud: ti.types.ndarray(ti.f32, ndim=2),  # (N, 3)
     point_invalid_mask: ti.types.ndarray(ti.i8, ndim=1),  # (N)
     camera_intrinsics: ti.types.ndarray(ti.f32, ndim=2),  # (3, 3)
-    T_camera_pointcloud: ti.types.ndarray(ti.f32, ndim=2),  # (4, 4)
+    point_object_id: ti.types.ndarray(ti.i32, ndim=1),  # (N)
+    q_camera_pointcloud: ti.types.ndarray(ti.f32, ndim=2),  # (K, 4)
+    t_camera_pointcloud: ti.types.ndarray(ti.f32, ndim=2),  # (K, 3)
     point_in_camera_mask: ti.types.ndarray(ti.i8, ndim=1),  # (N)
     near_plane: ti.f32,
     far_plane: ti.f32,
     camera_width: ti.i32,
     camera_height: ti.i32,
 ):
-    T_camera_pointcloud_mat = ti.Matrix(
-        [[T_camera_pointcloud[row, col] for col in range(4)] for row in range(4)])
     camera_intrinsics_mat = ti.Matrix(
         [[camera_intrinsics[row, col] for col in range(3)] for row in range(3)])
 
@@ -45,6 +47,14 @@ def filter_point_in_camera(
             continue
         point_xyz = ti.Vector(
             [pointcloud[point_id, 0], pointcloud[point_id, 1], pointcloud[point_id, 2]])
+        point_q_camera_pointcloud = ti.Vector(
+            [q_camera_pointcloud[point_object_id[point_id], idx] for idx in ti.static(range(4))])
+        point_t_camera_pointcloud = ti.Vector(
+            [t_camera_pointcloud[point_object_id[point_id], idx] for idx in ti.static(range(3))])
+        T_camera_pointcloud_mat = tranform_matrix_from_quaternion_and_translation(
+            q=point_q_camera_pointcloud,
+            t=point_t_camera_pointcloud,
+        )
         pixel_uv, point_in_camera = project_point_to_camera(
             translation=point_xyz,
             T_camera_world=T_camera_pointcloud_mat,
@@ -66,21 +76,29 @@ def filter_point_in_camera(
 def generate_point_sort_key(
     pointcloud: ti.types.ndarray(ti.f32, ndim=2),  # (N, 3)
     camera_intrinsics: ti.types.ndarray(ti.f32, ndim=2),  # (3, 3)
-    T_camera_pointcloud: ti.types.ndarray(ti.f32, ndim=2),  # (4, 4)
+    point_object_id: ti.types.ndarray(ti.i32, ndim=1),  # (N), we allow points belong to different objects, different objects may have different camera poses. By moving camera, we can actually handle moving objects.
+    q_camera_pointcloud: ti.types.ndarray(ti.f32, ndim=2),  # (K, 4), K is number of objects
+    t_camera_pointcloud: ti.types.ndarray(ti.f32, ndim=2),  # (K, 3), K is number of objects
     point_in_camera_id: ti.types.ndarray(ti.i32, ndim=1),  # (M)
     point_in_camera_sort_key: ti.types.ndarray(ti.i64, ndim=1),  # (M)
     camera_width: ti.i32,  # required to be multiple of 16
     camera_height: ti.i32,
     depth_to_sort_key_scale: ti.f32,
 ):
-    T_camera_pointcloud_mat = ti.Matrix(
-        [[T_camera_pointcloud[row, col] for col in ti.static(range(4))] for row in ti.static(range(4))])
     camera_intrinsics_mat = ti.Matrix(
         [[camera_intrinsics[row, col] for col in ti.static(range(3))] for row in ti.static(range(3))])
     for idx in range(point_in_camera_id.shape[0]):
         point_id = point_in_camera_id[idx]
         point_xyz = ti.Vector(
             [pointcloud[point_id, 0], pointcloud[point_id, 1], pointcloud[point_id, 2]])
+        point_q_camera_pointcloud = ti.Vector(
+            [q_camera_pointcloud[point_object_id[point_id], idx] for idx in ti.static(range(4))])
+        point_t_camera_pointcloud = ti.Vector(
+            [t_camera_pointcloud[point_object_id[point_id], idx] for idx in ti.static(range(3))])
+        T_camera_pointcloud_mat = tranform_matrix_from_quaternion_and_translation(
+            q=point_q_camera_pointcloud,
+            t=point_t_camera_pointcloud,
+        )
         pixel_uv, point_in_camera = project_point_to_camera(
             translation=point_xyz,
             T_camera_world=T_camera_pointcloud_mat,
@@ -98,7 +116,10 @@ def generate_point_sort_key(
             (ti.cast(encoded_tile_id, ti.i64) << 32)
         point_in_camera_sort_key[idx] = sort_key
 
-HALF_NEIGHBOR_TILE_SIZE = 7 # in paper it is 8
+
+HALF_NEIGHBOR_TILE_SIZE = 7  # in paper it is 8
+
+
 @ti.kernel
 def generate_num_overlap_tiles(
     num_overlap_tiles: ti.types.ndarray(ti.i32, ndim=1),  # (M)
@@ -110,18 +131,19 @@ def generate_num_overlap_tiles(
 ):
     for point_offset in range(num_overlap_tiles.shape[0]):
         uv = ti.math.vec2([point_uv[point_offset, 0],
-                            point_uv[point_offset, 1]])
+                           point_uv[point_offset, 1]])
         uv_cov = ti.math.mat2([point_uv_covariance[point_offset, 0, 0], point_uv_covariance[point_offset, 0, 1],
-                                point_uv_covariance[point_offset, 1, 0], point_uv_covariance[point_offset, 1, 1]])
+                               point_uv_covariance[point_offset, 1, 0], point_uv_covariance[point_offset, 1, 1]])
         point_alpha_after_activation_value = point_alpha_after_activation[point_offset]
-        
+
         center_tile_u = ti.cast(uv[0] // 16, ti.i32)
         center_tile_v = ti.cast(uv[1] // 16, ti.i32)
 
         # eigen_values, eigen_vectors = ti.sym_eig(uv_cov)
-        large_eigen_values = (uv_cov[0, 0] + uv_cov[1, 1] + \
-            ti.sqrt((uv_cov[0, 0] - uv_cov[1, 1]) * (uv_cov[0, 0] - uv_cov[1, 1]) + 4.0 * uv_cov[0, 1] * uv_cov[1, 0])) / 2.0
-        search_size = ti.sqrt(large_eigen_values) * 3.0 # 3.0 is a value from experiment
+        large_eigen_values = (uv_cov[0, 0] + uv_cov[1, 1] +
+                              ti.sqrt((uv_cov[0, 0] - uv_cov[1, 1]) * (uv_cov[0, 0] - uv_cov[1, 1]) + 4.0 * uv_cov[0, 1] * uv_cov[1, 0])) / 2.0
+        # 3.0 is a value from experiment
+        search_size = ti.sqrt(large_eigen_values) * 3.0
         tile_search_size = ti.cast(ti.ceil(search_size / 16.0), ti.i32)
         tile_search_size = ti.max(tile_search_size, 1)
 
@@ -170,10 +192,11 @@ def generate_num_overlap_tiles(
                         gaussian_covariance=uv_cov,
                     ))
                     if gaussian_alpha * point_alpha_after_activation_value > 1 / 255. or \
-                        (ti.abs(tile_u_offset) <= 1 and ti.abs(tile_v_offset) <= 1 and point_alpha_after_activation_value > 1 / 255.):
+                            (ti.abs(tile_u_offset) <= 1 and ti.abs(tile_v_offset) <= 1 and point_alpha_after_activation_value > 1 / 255.):
                         overlap_tiles_count += 1
         num_overlap_tiles[point_offset] = overlap_tiles_count
-    
+
+
 @ti.kernel
 def generate_point_sort_key_by_num_overlap_tiles(
     point_uv: ti.types.ndarray(ti.f32, ndim=2),  # (M, 2)
@@ -181,31 +204,34 @@ def generate_point_sort_key_by_num_overlap_tiles(
     point_uv_covariance: ti.types.ndarray(ti.f32, ndim=3),  # (M, 2, 2)
     point_alpha_after_activation: ti.types.ndarray(ti.f32, ndim=1),  # (M)
     accumulated_num_overlap_tiles: ti.types.ndarray(ti.i64, ndim=1),  # (M)
-    point_offset_with_sort_key: ti.types.ndarray(ti.i32, ndim=1),  # (K), K = sum(num_overlap_tiles)
-    point_in_camera_sort_key: ti.types.ndarray(ti.i64, ndim=1),  # (K), K = sum(num_overlap_tiles)
+    # (K), K = sum(num_overlap_tiles)
+    point_offset_with_sort_key: ti.types.ndarray(ti.i32, ndim=1),
+    # (K), K = sum(num_overlap_tiles)
+    point_in_camera_sort_key: ti.types.ndarray(ti.i64, ndim=1),
     camera_width: ti.i32,  # required to be multiple of 16
     camera_height: ti.i32,
     depth_to_sort_key_scale: ti.f32,
 ):
     for point_offset in range(accumulated_num_overlap_tiles.shape[0]):
         uv = ti.math.vec2([point_uv[point_offset, 0],
-                            point_uv[point_offset, 1]])
+                           point_uv[point_offset, 1]])
         xyz_in_camera = ti.math.vec3(
             [point_in_camera[point_offset, 0], point_in_camera[point_offset, 1], point_in_camera[point_offset, 2]])
         uv_cov = ti.math.mat2([point_uv_covariance[point_offset, 0, 0], point_uv_covariance[point_offset, 0, 1],
-                                point_uv_covariance[point_offset, 1, 0], point_uv_covariance[point_offset, 1, 1]])
+                               point_uv_covariance[point_offset, 1, 0], point_uv_covariance[point_offset, 1, 1]])
         point_alpha_after_activation_value = point_alpha_after_activation[point_offset]
 
         point_depth = xyz_in_camera[2]
         encoded_projected_depth = ti.cast(
-            point_depth * depth_to_sort_key_scale, ti.i32)       
+            point_depth * depth_to_sort_key_scale, ti.i32)
         center_tile_u = ti.cast(uv[0] // 16, ti.i32)
         center_tile_v = ti.cast(uv[1] // 16, ti.i32)
 
         # eigen_values, eigen_vectors = ti.sym_eig(uv_cov)
-        large_eigen_values = (uv_cov[0, 0] + uv_cov[1, 1] + \
-            ti.sqrt((uv_cov[0, 0] - uv_cov[1, 1]) * (uv_cov[0, 0] - uv_cov[1, 1]) + 4.0 * uv_cov[0, 1] * uv_cov[1, 0])) / 2.0
-        search_size = ti.sqrt(large_eigen_values) * 3.0 # 3.0 is a value from experiment
+        large_eigen_values = (uv_cov[0, 0] + uv_cov[1, 1] +
+                              ti.sqrt((uv_cov[0, 0] - uv_cov[1, 1]) * (uv_cov[0, 0] - uv_cov[1, 1]) + 4.0 * uv_cov[0, 1] * uv_cov[1, 0])) / 2.0
+        # 3.0 is a value from experiment
+        search_size = ti.sqrt(large_eigen_values) * 3.0
         tile_search_size = ti.cast(ti.ceil(search_size / 16.0), ti.i32)
         tile_search_size = ti.max(tile_search_size, 1)
 
@@ -252,10 +278,11 @@ def generate_point_sort_key_by_num_overlap_tiles(
                         gaussian_mean=uv,
                         gaussian_covariance=uv_cov,
                     ))
-                    
+
                     if gaussian_alpha * point_alpha_after_activation_value > 1 / 255. or \
-                        (ti.abs(tile_u_offset) <= 1 and ti.abs(tile_v_offset) <= 1 and point_alpha_after_activation_value > 1 / 255.):
-                        key_idx = accumulated_num_overlap_tiles[point_offset] + overlap_tiles_count
+                            (ti.abs(tile_u_offset) <= 1 and ti.abs(tile_v_offset) <= 1 and point_alpha_after_activation_value > 1 / 255.):
+                        key_idx = accumulated_num_overlap_tiles[point_offset] + \
+                            overlap_tiles_count
                         encoded_tile_id = ti.cast(
                             tile_u + tile_v * (camera_width // 16), ti.i32)
                         sort_key = ti.cast(encoded_projected_depth, ti.i64) + \
@@ -263,6 +290,7 @@ def generate_point_sort_key_by_num_overlap_tiles(
                         point_in_camera_sort_key[key_idx] = sort_key
                         point_offset_with_sort_key[key_idx] = point_offset
                         overlap_tiles_count += 1
+
 
 @ti.kernel
 def find_tile_start_and_end(
@@ -333,25 +361,19 @@ def generate_point_attributes_in_camera_plane(
     pointcloud: ti.types.ndarray(ti.f32, ndim=2),  # (N, 3)
     pointcloud_features: ti.types.ndarray(ti.f32, ndim=2),  # (N, M)
     camera_intrinsics: ti.types.ndarray(ti.f32, ndim=2),  # (3, 3)
-    T_camera_pointcloud: ti.types.ndarray(ti.f32, ndim=2),  # (4, 4)
+    point_object_id: ti.types.ndarray(ti.i32, ndim=1),  # (N)
+    q_camera_pointcloud: ti.types.ndarray(ti.f32, ndim=2),  # (K, 4)
+    t_camera_pointcloud: ti.types.ndarray(ti.f32, ndim=2),  # (K, 3)
     point_id_list: ti.types.ndarray(ti.i32, ndim=1),  # (M)
     point_uv: ti.types.ndarray(ti.f32, ndim=2),  # (M, 2)
     point_in_camera: ti.types.ndarray(ti.f32, ndim=2),  # (M, 3)
     point_uv_covariance: ti.types.ndarray(ti.f32, ndim=3),  # (M, 2, 2)
     point_alpha_after_activation: ti.types.ndarray(ti.f32, ndim=1),  # (M)
     point_color: ti.types.ndarray(ti.f32, ndim=2),  # (M, 3)
-    has_extra_rotation_and_scale: ti.template(), # only true for inference only
-    point_extra_translation: ti.types.ndarray(ti.f32, ndim=2),  # (N, 3) or (empty) actually translation part of SE3 T_inference_train(from train coord to inference coord)
-    point_extra_rotation: ti.types.ndarray(ti.f32, ndim=2),  # (N, 4) or (empty) actually rotation part of SE3 T_inference_train(from train coord to inference coord)
-    point_extra_scale: ti.types.ndarray(ti.f32, ndim=2),  # (N, 3) or (empty) actually scale matrix S_inference_train(from train coord to inference coord)
 ):
-    T_camera_pointcloud_mat = ti.Matrix(
-        [[T_camera_pointcloud[row, col] for col in ti.static(range(4))] for row in ti.static(range(4))])
     camera_intrinsics_mat = ti.Matrix(
         [[camera_intrinsics[row, col] for col in ti.static(range(3))] for row in ti.static(range(3))])
-    T_pointcloud_camera = taichi_inverse_se3(T_camera_pointcloud_mat)
-    ray_origin = ti.math.vec3(
-        [T_pointcloud_camera[0, 3], T_pointcloud_camera[1, 3], T_pointcloud_camera[2, 3]])
+    
     for idx in range(point_id_list.shape[0]):
         point_id = point_id_list[idx]
         normalize_cov_rotation_in_pointcloud_features(
@@ -361,87 +383,46 @@ def generate_point_attributes_in_camera_plane(
             pointcloud=pointcloud,
             pointcloud_features=pointcloud_features,
             point_id=point_id)
-        
-        # taichi has a more strict scope than python, so we need to declare variables here
-        uv = ti.math.vec2([0., 0.])
-        xyz_in_camera = ti.math.vec3([0., 0., 0.])
-        uv_cov = ti.Matrix([[0., 0.], [0., 0.]])
-        
-        if has_extra_rotation_and_scale:
-            extra_translation = ti.math.vec3(
-                point_extra_translation[point_id, 0], point_extra_translation[point_id, 1], point_extra_translation[point_id, 2])
-            extra_rotation = ti.math.vec4(
-                point_extra_rotation[point_id, 0], point_extra_rotation[point_id, 1], point_extra_rotation[point_id, 2], point_extra_rotation[point_id, 3])
-            extra_scale = ti.math.vec3(
-                point_extra_scale[point_id, 0], point_extra_scale[point_id, 1], point_extra_scale[point_id, 2])
-            uv, xyz_in_camera = gaussian_point_3d.project_to_camera_position_with_extra_translation_and_rotation_and_scale(
-                T_camera_world=T_camera_pointcloud_mat,
-                projective_transform=camera_intrinsics_mat,
-                extra_translation=extra_translation,
-                extra_rotation=extra_rotation,
-                extra_scale=extra_scale,
-            )
-            uv_cov = gaussian_point_3d.project_to_camera_covariance_with_extra_rotation_and_scale(
-                T_camera_world=T_camera_pointcloud_mat,
-                projective_transform=camera_intrinsics_mat,
-                translation_camera=xyz_in_camera,
-                extra_rotation_quaternion=extra_rotation,
-                extra_scale=extra_scale,
-            )
-        else:
-            uv, xyz_in_camera = gaussian_point_3d.project_to_camera_position(
-                T_camera_world=T_camera_pointcloud_mat,
-                projective_transform=camera_intrinsics_mat,
-            )
-            uv_cov = gaussian_point_3d.project_to_camera_covariance(
-                T_camera_world=T_camera_pointcloud_mat,
-                projective_transform=camera_intrinsics_mat,
-                translation_camera=xyz_in_camera,
-            )   
-                
+
+        point_q_camera_pointcloud = ti.Vector(
+            [q_camera_pointcloud[point_object_id[point_id], idx] for idx in ti.static(range(4))])
+        point_t_camera_pointcloud = ti.Vector(
+            [t_camera_pointcloud[point_object_id[point_id], idx] for idx in ti.static(range(3))])
+        T_camera_pointcloud_mat = tranform_matrix_from_quaternion_and_translation(
+            q=point_q_camera_pointcloud,
+            t=point_t_camera_pointcloud,
+        )
+        T_pointcloud_camera = taichi_inverse_se3(T_camera_pointcloud_mat)
+        ray_origin = ti.math.vec3(
+            [T_pointcloud_camera[0, 3], T_pointcloud_camera[1, 3], T_pointcloud_camera[2, 3]])
+
+        uv, xyz_in_camera = gaussian_point_3d.project_to_camera_position(
+            T_camera_world=T_camera_pointcloud_mat,
+            projective_transform=camera_intrinsics_mat,
+        )
+        uv_cov = gaussian_point_3d.project_to_camera_covariance(
+            T_camera_world=T_camera_pointcloud_mat,
+            projective_transform=camera_intrinsics_mat,
+            translation_camera=xyz_in_camera,
+        )
+
         point_uv[idx, 0], point_uv[idx, 1] = uv[0], uv[1]
         point_in_camera[idx, 0], point_in_camera[idx, 1], point_in_camera[idx,
                                                                           2] = xyz_in_camera[0], xyz_in_camera[1], xyz_in_camera[2]
         point_uv_covariance[idx, 0, 0], point_uv_covariance[idx, 0, 1], point_uv_covariance[idx, 1,
                                                                                             0], point_uv_covariance[idx, 1, 1] = uv_cov[0, 0], uv_cov[0, 1], uv_cov[1, 0], uv_cov[1, 1]
         point_alpha_after_activation[idx] = 1. / \
-                (1. + ti.math.exp(-gaussian_point_3d.alpha))
-        
-        # declare variables here, decide implementation based on template
-        ray_direction = ti.math.vec3([0., 0., 0.])
-        if has_extra_rotation_and_scale:
-            t_inference_train = ti.math.vec3([
-                point_extra_translation[point_id, 0], point_extra_translation[point_id, 1], point_extra_translation[point_id, 2]])
-            q_inference_train = ti.math.vec4([
-                point_extra_rotation[point_id, 0], point_extra_rotation[point_id, 1], point_extra_rotation[point_id, 2], point_extra_rotation[point_id, 3]])
-            s_inference_train = ti.math.vec3([
-                point_extra_scale[point_id, 0], point_extra_scale[point_id, 1], point_extra_scale[point_id, 2]])
-            R_inference_train = rotation_matrix_from_quaternion(q_inference_train)
-            T_inference_train = ti.math.mat4([
-                [R_inference_train[0, 0], R_inference_train[0, 1], R_inference_train[0, 2], t_inference_train[0]],
-                [R_inference_train[1, 0], R_inference_train[1, 1], R_inference_train[1, 2], t_inference_train[1]],
-                [R_inference_train[2, 0], R_inference_train[2, 1], R_inference_train[2, 2], t_inference_train[2]],
-                [0., 0., 0., 1.]
-            ])
-            T_train_inference = taichi_inverse_se3(T_inference_train)
-            S_train_inference = ti.math.mat3([
-                [1. / s_inference_train[0], 0., 0.],
-                [0., 1. / s_inference_train[1], 0.],
-                [0., 0., 1. / s_inference_train[2]]
-            ])
-            ray_origin_tmp = T_train_inference @ ti.math.vec4([ray_origin[0], ray_origin[1], ray_origin[2], 1.])
-            ray_origin_train = S_train_inference @ ti.math.vec3([ray_origin_tmp[0], ray_origin_tmp[1], ray_origin_tmp[2]])
-            
-            ray_direction = gaussian_point_3d.translation - ray_origin_train
-        else:
-            ray_direction = gaussian_point_3d.translation - ray_origin
-        
+            (1. + ti.math.exp(-gaussian_point_3d.alpha))
+
+        ray_direction = gaussian_point_3d.translation - ray_origin
+
         # get color by ray actually only cares about the direction of the ray, ray origin is not used
         color = gaussian_point_3d.get_color_by_ray(
             ray_origin=ray_origin,
             ray_direction=ray_direction,
         )
-        point_color[idx, 0], point_color[idx, 1], point_color[idx, 2] = color[0], color[1], color[2]
+        point_color[idx, 0], point_color[idx,
+                                         1], point_color[idx, 2] = color[0], color[1], color[2]
 
 
 @ti.kernel
@@ -455,7 +436,8 @@ def gaussian_point_rasterisation(
     # (tiles_per_row * tiles_per_col)
     tile_points_end: ti.types.ndarray(ti.i32, ndim=1),
     point_id_in_camera_list: ti.types.ndarray(ti.i32, ndim=1),  # (M)
-    point_offset_with_sort_key: ti.types.ndarray(ti.i32, ndim=1),  # (K) the offset of the point in point_id_in_camera_list
+    # (K) the offset of the point in point_id_in_camera_list
+    point_offset_with_sort_key: ti.types.ndarray(ti.i32, ndim=1),
     point_uv: ti.types.ndarray(ti.f32, ndim=2),  # (M, 2)
     point_in_camera: ti.types.ndarray(ti.f32, ndim=2),  # (M, 3)
     point_uv_covariance: ti.types.ndarray(ti.f32, ndim=3),  # (M, 2, 2)
@@ -481,22 +463,24 @@ def gaussian_point_rasterisation(
         start_offset = tile_points_start[tile_id]
         end_offset = tile_points_end[tile_id]
         T_i = 1.0
-        accumulated_alpha = 0. # accumulated alpha is 1.0 - T_i
+        accumulated_alpha = 0.  # accumulated alpha is 1.0 - T_i
         accumulated_color = ti.math.vec3([0., 0., 0.])
         accumulated_depth = 0.
         depth_normalization_factor = 0.
         offset_of_last_effective_point = start_offset
-        
+
         valid_point_count: ti.i32 = 0
 
         tile_point_uv = ti.simt.block.SharedArray((256, 2), dtype=ti.f32)
-        tile_point_uv_cov = ti.simt.block.SharedArray((256, 2, 2), dtype=ti.f32)
+        tile_point_uv_cov = ti.simt.block.SharedArray(
+            (256, 2, 2), dtype=ti.f32)
         tile_point_depth = ti.simt.block.SharedArray(256, dtype=ti.f32)
         tile_point_alpha = ti.simt.block.SharedArray(256, dtype=ti.f32)
         tile_point_color = ti.simt.block.SharedArray((256, 3), dtype=ti.f32)
-        tile_saturated_pixel_count = ti.simt.block.SharedArray((1,), dtype=ti.i32) 
+        tile_saturated_pixel_count = ti.simt.block.SharedArray(
+            (1,), dtype=ti.i32)
         tile_saturated_pixel_count[0] = 0
-        
+
         num_points_in_tile = end_offset - start_offset
         num_point_groups = (num_points_in_tile + 255) // 256
         pixel_saturated = False
@@ -504,7 +488,8 @@ def gaussian_point_rasterisation(
         for point_group_id in range(num_point_groups):
             # load point data into shared memory
             # [start_offset, end_offset)->[0, end_offset - start_offset)
-            to_load_idx_point_offset_with_sort_key = start_offset + point_group_id * 256 + thread_id
+            to_load_idx_point_offset_with_sort_key = start_offset + \
+                point_group_id * 256 + thread_id
             if to_load_idx_point_offset_with_sort_key < end_offset:
                 to_load_point_offset = point_offset_with_sort_key[to_load_idx_point_offset_with_sort_key]
                 to_load_point_id = point_id_in_camera_list[to_load_point_offset]
@@ -514,31 +499,41 @@ def gaussian_point_rasterisation(
                     point_id=to_load_point_id)
                 tile_point_uv[thread_id, 0] = point_uv[to_load_point_offset, 0]
                 tile_point_uv[thread_id, 1] = point_uv[to_load_point_offset, 1]
-                tile_point_uv_cov[thread_id, 0, 0] = point_uv_covariance[to_load_point_offset, 0, 0]
-                tile_point_uv_cov[thread_id, 0, 1] = point_uv_covariance[to_load_point_offset, 0, 1]
-                tile_point_uv_cov[thread_id, 1, 0] = point_uv_covariance[to_load_point_offset, 1, 0]
-                tile_point_uv_cov[thread_id, 1, 1] = point_uv_covariance[to_load_point_offset, 1, 1]
+                tile_point_uv_cov[thread_id, 0,
+                                  0] = point_uv_covariance[to_load_point_offset, 0, 0]
+                tile_point_uv_cov[thread_id, 0,
+                                  1] = point_uv_covariance[to_load_point_offset, 0, 1]
+                tile_point_uv_cov[thread_id, 1,
+                                  0] = point_uv_covariance[to_load_point_offset, 1, 0]
+                tile_point_uv_cov[thread_id, 1,
+                                  1] = point_uv_covariance[to_load_point_offset, 1, 1]
                 tile_point_depth[thread_id] = point_in_camera[to_load_point_offset, 2]
                 tile_point_alpha[thread_id] = to_load_gaussian_point_3d.alpha
-                
-                tile_point_color[thread_id, 0] = point_color[to_load_point_offset, 0]
-                tile_point_color[thread_id, 1] = point_color[to_load_point_offset, 1]
-                tile_point_color[thread_id, 2] = point_color[to_load_point_offset, 2]
+
+                tile_point_color[thread_id,
+                                 0] = point_color[to_load_point_offset, 0]
+                tile_point_color[thread_id,
+                                 1] = point_color[to_load_point_offset, 1]
+                tile_point_color[thread_id,
+                                 2] = point_color[to_load_point_offset, 2]
 
             ti.simt.block.sync()
             for point_group_offset in range(256):
-                # forward rendering process                
-                idx_point_offset_with_sort_key = start_offset + point_group_id * 256 + point_group_offset
-                
+                # forward rendering process
+                idx_point_offset_with_sort_key = start_offset + \
+                    point_group_id * 256 + point_group_offset
+
                 if idx_point_offset_with_sort_key >= end_offset or pixel_saturated:
                     break
 
-                uv = ti.math.vec2([tile_point_uv[point_group_offset, 0], tile_point_uv[point_group_offset, 1]])
+                uv = ti.math.vec2(
+                    [tile_point_uv[point_group_offset, 0], tile_point_uv[point_group_offset, 1]])
                 depth = tile_point_depth[point_group_offset]
                 uv_cov = ti.math.mat2(tile_point_uv_cov[point_group_offset, 0, 0], tile_point_uv_cov[point_group_offset, 0, 1],
-                                        tile_point_uv_cov[point_group_offset, 1, 0], tile_point_uv_cov[point_group_offset, 1, 1])
+                                      tile_point_uv_cov[point_group_offset, 1, 0], tile_point_uv_cov[point_group_offset, 1, 1])
                 gaussian_point_3d_alpha = tile_point_alpha[point_group_offset]
-                color = ti.math.vec3([tile_point_color[point_group_offset, 0], tile_point_color[point_group_offset, 1], tile_point_color[point_group_offset, 2]])
+                color = ti.math.vec3([tile_point_color[point_group_offset, 0],
+                                     tile_point_color[point_group_offset, 1], tile_point_color[point_group_offset, 2]])
 
                 gaussian_alpha = get_point_probability_density_from_2d_gaussian_normalized(
                     xy=ti.math.vec2([pixel_u + 0.5, pixel_v + 0.5]),
@@ -570,7 +565,8 @@ def gaussian_point_rasterisation(
                 accumulated_alpha = 1. - T_i
                 valid_point_count += 1
             # end of point group loop
-            ti.simt.block.sync() # block the next update for shared memory until all threads finish the current update
+            # block the next update for shared memory until all threads finish the current update
+            ti.simt.block.sync()
             if tile_saturated_pixel_count[0] == 256:
                 break
 
@@ -579,7 +575,8 @@ def gaussian_point_rasterisation(
         rasterized_image[pixel_v, pixel_u, 0] = accumulated_color[0]
         rasterized_image[pixel_v, pixel_u, 1] = accumulated_color[1]
         rasterized_image[pixel_v, pixel_u, 2] = accumulated_color[2]
-        rasterized_depth[pixel_v, pixel_u] = accumulated_depth / ti.max(depth_normalization_factor, 1e-6)
+        rasterized_depth[pixel_v, pixel_u] = accumulated_depth / \
+            ti.max(depth_normalization_factor, 1e-6)
         pixel_accumulated_alpha[pixel_v, pixel_u] = accumulated_alpha
         pixel_offset_of_last_effective_point[pixel_v,
                                              pixel_u] = offset_of_last_effective_point
@@ -587,52 +584,16 @@ def gaussian_point_rasterisation(
     # end of pixel loop
 
 
-@ti.func
-def atomic_accumulate_grad_for_point(
-    point_id: ti.i32,
-    point_in_camera_grad: ti.types.ndarray(ti.f32, ndim=2),  # (M, 3)
-    pointfeatures_grad: ti.types.ndarray(ti.f32, ndim=2),  # (M, K)
-    viewspace_grad: ti.types.ndarray(ti.f32, ndim=2),  # (M, 2)
-    point_viewspace_grad: ti.math.vec2,
-    translation_grad: ti.math.vec3,
-    gaussian_q_grad: ti.math.vec4,
-    gaussian_s_grad: ti.math.vec3,
-    gaussian_point_3d_alpha_grad: ti.f32,
-    color_r_grad: vec16f,
-    color_g_grad: vec16f,
-    color_b_grad: vec16f,
-):
-    ti.atomic_add(viewspace_grad[point_id, 0], point_viewspace_grad[0])
-    ti.atomic_add(viewspace_grad[point_id, 1], point_viewspace_grad[1])
-    for offset in ti.static(range(3)):
-        ti.atomic_add(point_in_camera_grad[point_id, offset],
-                      translation_grad[offset])
-    for offset in ti.static(range(4)):
-        ti.atomic_add(pointfeatures_grad[point_id, offset],
-                      gaussian_q_grad[offset])
-    for offset in ti.static(range(3)):
-        ti.atomic_add(pointfeatures_grad[point_id, 4 + offset],
-                      gaussian_s_grad[offset])
-    ti.atomic_add(pointfeatures_grad[point_id, 7],
-                  gaussian_point_3d_alpha_grad)
-
-    for offset in ti.static(range(16)):
-        ti.atomic_add(pointfeatures_grad[point_id, 8 + offset],
-                      color_r_grad[offset])
-        ti.atomic_add(pointfeatures_grad[point_id, 24 + offset],
-                      color_g_grad[offset])
-        ti.atomic_add(pointfeatures_grad[point_id, 40 + offset],
-                      color_b_grad[offset])
-
-
 @ti.kernel
 def gaussian_point_rasterisation_backward(
     camera_height: ti.i32,
     camera_width: ti.i32,
     camera_intrinsics: ti.types.ndarray(ti.f32, ndim=2),  # (3, 3)
-    T_camera_pointcloud: ti.types.ndarray(ti.f32, ndim=2),  # (4, 4)
     pointcloud: ti.types.ndarray(ti.f32, ndim=2),  # (N, 3)
     pointcloud_features: ti.types.ndarray(ti.f32, ndim=2),  # (N, K)
+    point_object_id: ti.types.ndarray(ti.i32, ndim=1),  # (N)
+    q_camera_pointcloud: ti.types.ndarray(ti.f32, ndim=2),  # (K, 4)
+    t_camera_pointcloud: ti.types.ndarray(ti.f32, ndim=2),  # (K, 3)
     # (tiles_per_row * tiles_per_col)
     tile_points_start: ti.types.ndarray(ti.i32, ndim=1),
     tile_points_end: ti.types.ndarray(ti.i32, ndim=1),
@@ -646,44 +607,50 @@ def gaussian_point_rasterisation_backward(
     grad_pointcloud_features: ti.types.ndarray(ti.f32, ndim=2),  # (N, K)
     grad_uv: ti.types.ndarray(ti.f32, ndim=2),  # (N, 2)
     magnitude_grad_uv: ti.types.ndarray(ti.f32, ndim=2),  # (N, 2)
-    magnitude_grad_viewspace_on_image: ti.types.ndarray(ti.f32, ndim=3),  # (H, W, 2)
-    in_camera_grad_uv_cov_buffer: ti.types.ndarray(ti.f32, ndim=3),  # (M, 2, 2)
+    # (H, W, 2)
+    magnitude_grad_viewspace_on_image: ti.types.ndarray(ti.f32, ndim=3),
+    # (M, 2, 2)
+    in_camera_grad_uv_cov_buffer: ti.types.ndarray(ti.f32, ndim=3),
     in_camera_grad_color_buffer: ti.types.ndarray(ti.f32, ndim=2),  # (M, 3)
     in_camera_depth: ti.types.ndarray(ti.f32, ndim=1),  # (M)
     in_camera_uv: ti.types.ndarray(ti.f32, ndim=2),  # (M, 2)
     in_camera_num_affected_pixels: ti.types.ndarray(ti.i32, ndim=1),  # (M)
 ):
-    T_camera_pointcloud_mat = ti.Matrix(
-        [[T_camera_pointcloud[row, col] for col in ti.static(range(4))] for row in ti.static(range(4))])
     camera_intrinsics_mat = ti.Matrix(
         [[camera_intrinsics[row, col] for col in ti.static(range(3))] for row in ti.static(range(3))])
-    T_pointcloud_camera = taichi_inverse_se3(T_camera_pointcloud_mat)
-    ray_origin = ti.math.vec3(
-        [T_pointcloud_camera[0, 3], T_pointcloud_camera[1, 3], T_pointcloud_camera[2, 3]])
 
     ti.loop_config(block_dim=256)
     for pixel_offset in ti.ndrange(camera_height * camera_width):
-        tile_id = pixel_offset // 256 # each block handles one tile, so tile_id is actually block_id
+        # each block handles one tile, so tile_id is actually block_id
+        tile_id = pixel_offset // 256
         thread_id = pixel_offset % 256
         tile_u = ti.cast(tile_id % (camera_width // 16), ti.i32)
         tile_v = ti.cast(tile_id // (camera_width // 16), ti.i32)
-        
+
         start_offset = tile_points_start[tile_id]
         end_offset = tile_points_end[tile_id]
         tile_point_count = end_offset - start_offset
 
-        
-        tile_point_uv = ti.simt.block.SharedArray((256, 2), dtype=ti.f32) # 2KB shared memory
-        tile_point_uv_cov = ti.simt.block.SharedArray((256, 2, 2), dtype=ti.f32) # 4KB shared memory
-        tile_point_color = ti.simt.block.SharedArray((256, 3), dtype=ti.f32) # 3KB shared memory
-        tile_point_alpha = ti.simt.block.SharedArray((256,), dtype=ti.f32) # 1KB shared memory
-        tile_point_grad_uv = ti.simt.block.SharedArray((256, 2), dtype=ti.f32) # 2KB shared memory
-        tile_point_abs_grad_uv = ti.simt.block.SharedArray((256, 2), dtype=ti.f32) # 2KB shared memory
-        tile_point_grad_uv_cov = ti.simt.block.SharedArray((256, 2, 2), dtype=ti.f32) # 4KB shared memory
-        tile_point_grad_color = ti.simt.block.SharedArray((256, 3), dtype=ti.f32) # 3KB shared memory
-        tile_point_grad_alpha = ti.simt.block.SharedArray((256,), dtype=ti.f32) # 1KB shared memory
-        tile_point_num_affected_pixels = ti.simt.block.SharedArray((256,), dtype=ti.i32) # 1KB shared memory
-        
+        tile_point_uv = ti.simt.block.SharedArray(
+            (256, 2), dtype=ti.f32)  # 2KB shared memory
+        tile_point_uv_cov = ti.simt.block.SharedArray(
+            (256, 2, 2), dtype=ti.f32)  # 4KB shared memory
+        tile_point_color = ti.simt.block.SharedArray(
+            (256, 3), dtype=ti.f32)  # 3KB shared memory
+        tile_point_alpha = ti.simt.block.SharedArray(
+            (256,), dtype=ti.f32)  # 1KB shared memory
+        tile_point_grad_uv = ti.simt.block.SharedArray(
+            (256, 2), dtype=ti.f32)  # 2KB shared memory
+        tile_point_abs_grad_uv = ti.simt.block.SharedArray(
+            (256, 2), dtype=ti.f32)  # 2KB shared memory
+        tile_point_grad_uv_cov = ti.simt.block.SharedArray(
+            (256, 2, 2), dtype=ti.f32)  # 4KB shared memory
+        tile_point_grad_color = ti.simt.block.SharedArray(
+            (256, 3), dtype=ti.f32)  # 3KB shared memory
+        tile_point_grad_alpha = ti.simt.block.SharedArray(
+            (256,), dtype=ti.f32)  # 1KB shared memory
+        tile_point_num_affected_pixels = ti.simt.block.SharedArray(
+            (256,), dtype=ti.i32)  # 1KB shared memory
 
         pixel_offset_in_tile = pixel_offset - tile_id * 256
         pixel_offset_u_in_tile = pixel_offset_in_tile % 16
@@ -692,17 +659,17 @@ def gaussian_point_rasterisation_backward(
         pixel_v = tile_v * 16 + pixel_offset_v_in_tile
         last_effective_point = pixel_offset_of_last_effective_point[pixel_v, pixel_u]
         accumulated_alpha: ti.f32 = pixel_accumulated_alpha[pixel_v, pixel_u]
-        T_i = 1.0 - accumulated_alpha # T_i = \prod_{j=1}^{i-1} (1 - a_j)
+        T_i = 1.0 - accumulated_alpha  # T_i = \prod_{j=1}^{i-1} (1 - a_j)
         # \frac{dC}{da_i} = c_i T(i) - \frac{1}{1 - a_i} \sum_{j=i+1}^{n} c_j a_j T(j)
         # let w_i = \sum_{j=i+1}^{n} c_j a_j T(j)
         # we have w_n = 0, w_{i-1} = w_i + c_i a_i T(i)
         # \frac{dC}{da_i} = c_i T(i) - \frac{1}{1 - a_i} w_i
         w_i = ti.math.vec3(0.0, 0.0, 0.0)
-        
+
         pixel_rgb_grad = ti.math.vec3(
             rasterized_image_grad[pixel_v, pixel_u, 0], rasterized_image_grad[pixel_v, pixel_u, 1], rasterized_image_grad[pixel_v, pixel_u, 2])
         total_magnitude_grad_viewspace_on_image = ti.math.vec2(0.0, 0.0)
-       
+
         # for inverse_point_offset in range(effective_point_count):
         # taichi only supports range() with start and end
         # for inverse_point_offset_base in range(0, tile_point_count, 256):
@@ -710,20 +677,34 @@ def gaussian_point_rasterisation_backward(
         for point_block_id in range(num_point_blocks):
             inverse_point_offset_base = point_block_id * 256
             block_end_idx_point_offset_with_sort_key = end_offset - inverse_point_offset_base
-            block_start_idx_point_offset_with_sort_key = ti.max(block_end_idx_point_offset_with_sort_key - 256, 0)
+            block_start_idx_point_offset_with_sort_key = ti.max(
+                block_end_idx_point_offset_with_sort_key - 256, 0)
             # in the later loop, we will handle the points in [block_start_idx_point_offset_with_sort_key, block_end_idx_point_offset_with_sort_key)
             # so we need to load the points in [block_start_idx_point_offset_with_sort_key, block_end_idx_point_offset_with_sort_key - 1]
             to_load_idx_point_offset_with_sort_key = block_end_idx_point_offset_with_sort_key - thread_id - 1
             if to_load_idx_point_offset_with_sort_key >= block_start_idx_point_offset_with_sort_key:
                 to_load_point_offset = point_offset_with_sort_key[to_load_idx_point_offset_with_sort_key]
                 to_load_point_id = point_id_in_camera_list[to_load_point_offset]
+                point_q_camera_pointcloud = ti.Vector(
+                    [q_camera_pointcloud[point_object_id[to_load_point_id], idx] for idx in ti.static(range(4))])
+                point_t_camera_pointcloud = ti.Vector(
+                    [t_camera_pointcloud[point_object_id[to_load_point_id], idx] for idx in ti.static(range(3))])
+                T_camera_pointcloud_mat = tranform_matrix_from_quaternion_and_translation(
+                    q=point_q_camera_pointcloud,
+                    t=point_t_camera_pointcloud,
+                )
+
+                T_pointcloud_camera = taichi_inverse_se3(
+                    T_camera_pointcloud_mat)
+                ray_origin = ti.math.vec3(
+                    [T_pointcloud_camera[0, 3], T_pointcloud_camera[1, 3], T_pointcloud_camera[2, 3]])
                 to_load_gaussian_point_3d = load_point_cloud_row_into_gaussian_point_3d(
                     pointcloud=pointcloud,
                     pointcloud_features=pointcloud_features,
                     point_id=to_load_point_id)
                 to_load_uv, to_load_translation_camera = to_load_gaussian_point_3d.project_to_camera_position(
                     T_camera_world=T_camera_pointcloud_mat,
-                    projective_transform=camera_intrinsics_mat)       
+                    projective_transform=camera_intrinsics_mat)
                 for i in ti.static(range(2)):
                     tile_point_uv[thread_id, i] = to_load_uv[i]
                     tile_point_grad_uv[thread_id, i] = 0.0
@@ -734,7 +715,8 @@ def gaussian_point_rasterisation_backward(
                     translation_camera=to_load_translation_camera)
                 for i in ti.static(range(2)):
                     for j in ti.static(range(2)):
-                        tile_point_uv_cov[thread_id, i, j] = to_load_uv_cov[i, j]
+                        tile_point_uv_cov[thread_id, i,
+                                          j] = to_load_uv_cov[i, j]
                         tile_point_grad_uv_cov[thread_id, i, j] = 0.0
                 to_load_ray_direction = to_load_gaussian_point_3d.translation - ray_origin
                 to_load_color = to_load_gaussian_point_3d.get_color_by_ray(
@@ -744,11 +726,11 @@ def gaussian_point_rasterisation_backward(
                 for i in ti.static(range(3)):
                     tile_point_color[thread_id, i] = to_load_color[i]
                     tile_point_grad_color[thread_id, i] = 0.0
-                
+
                 tile_point_alpha[thread_id] = to_load_gaussian_point_3d.alpha
                 tile_point_grad_alpha[thread_id] = 0.0
                 tile_point_num_affected_pixels[thread_id] = 0
-                
+
             ti.simt.block.sync()
             for inverse_point_offset_offset in range(256):
                 inverse_point_offset = inverse_point_offset_base + inverse_point_offset_offset
@@ -760,12 +742,14 @@ def gaussian_point_rasterisation_backward(
                     continue
 
                 idx_point_offset_with_sort_key_in_block = inverse_point_offset_offset
-                uv = ti.math.vec2(tile_point_uv[idx_point_offset_with_sort_key_in_block, 0], tile_point_uv[idx_point_offset_with_sort_key_in_block, 1])
+                uv = ti.math.vec2(tile_point_uv[idx_point_offset_with_sort_key_in_block, 0],
+                                  tile_point_uv[idx_point_offset_with_sort_key_in_block, 1])
                 uv_cov = ti.math.mat2([
-                    tile_point_uv_cov[idx_point_offset_with_sort_key_in_block, 0, 0], tile_point_uv_cov[idx_point_offset_with_sort_key_in_block, 0, 1],
-                    tile_point_uv_cov[idx_point_offset_with_sort_key_in_block, 1, 0], tile_point_uv_cov[idx_point_offset_with_sort_key_in_block, 1, 1],
+                    tile_point_uv_cov[idx_point_offset_with_sort_key_in_block, 0,
+                                      0], tile_point_uv_cov[idx_point_offset_with_sort_key_in_block, 0, 1],
+                    tile_point_uv_cov[idx_point_offset_with_sort_key_in_block, 1,
+                                      0], tile_point_uv_cov[idx_point_offset_with_sort_key_in_block, 1, 1],
                 ])
-
 
                 point_offset = point_offset_with_sort_key[idx_point_offset_with_sort_key]
                 point_id = point_id_in_camera_list[point_offset]
@@ -785,8 +769,8 @@ def gaussian_point_rasterisation_backward(
                 if prod_alpha >= 1. / 255.:
                     alpha: ti.f32 = ti.min(prod_alpha, 0.99)
                     color = ti.math.vec3([
-                        tile_point_color[idx_point_offset_with_sort_key_in_block, 0], 
-                        tile_point_color[idx_point_offset_with_sort_key_in_block, 1], 
+                        tile_point_color[idx_point_offset_with_sort_key_in_block, 0],
+                        tile_point_color[idx_point_offset_with_sort_key_in_block, 1],
                         tile_point_color[idx_point_offset_with_sort_key_in_block, 2]])
 
                     T_i = T_i / (1. - alpha)
@@ -797,7 +781,7 @@ def gaussian_point_rasterisation_backward(
 
                     d_pixel_rgb_d_color = alpha * T_i
                     point_grad_color = d_pixel_rgb_d_color * pixel_rgb_grad
-                    
+
                     # \frac{dC}{da_i} = c_i T(i) - \frac{1}{1 - a_i} w_i
                     alpha_grad_from_rgb = (color * T_i - w_i / (1. - alpha)) \
                         * pixel_rgb_grad
@@ -813,20 +797,28 @@ def gaussian_point_rasterisation_backward(
                     # gaussian_alpha_grad is dp
                     point_viewspace_grad = gaussian_alpha_grad * \
                         d_p_d_mean  # (2,) as the paper said, view space gradient is used for detect candidates for densification
-                    total_magnitude_grad_viewspace_on_image += ti.abs(point_viewspace_grad)
-                    point_uv_cov_grad = gaussian_alpha_grad * d_p_d_cov # (2, 2)
-                    
+                    total_magnitude_grad_viewspace_on_image += ti.abs(
+                        point_viewspace_grad)
+                    point_uv_cov_grad = gaussian_alpha_grad * \
+                        d_p_d_cov  # (2, 2)
+
                     # atomic accumulate on block shared memory shall be faster
                     for i in ti.static(range(2)):
-                        ti.atomic_add(tile_point_grad_uv[idx_point_offset_with_sort_key_in_block, i], point_viewspace_grad[i])
-                        ti.atomic_add(tile_point_abs_grad_uv[idx_point_offset_with_sort_key_in_block, i], ti.abs(point_viewspace_grad[i]))
+                        ti.atomic_add(
+                            tile_point_grad_uv[idx_point_offset_with_sort_key_in_block, i], point_viewspace_grad[i])
+                        ti.atomic_add(tile_point_abs_grad_uv[idx_point_offset_with_sort_key_in_block, i], ti.abs(
+                            point_viewspace_grad[i]))
                     for i in ti.static(range(2)):
                         for j in ti.static(range(2)):
-                            ti.atomic_add(tile_point_grad_uv_cov[idx_point_offset_with_sort_key_in_block, i, j], point_uv_cov_grad[i, j])
+                            ti.atomic_add(
+                                tile_point_grad_uv_cov[idx_point_offset_with_sort_key_in_block, i, j], point_uv_cov_grad[i, j])
                     for i in ti.static(range(3)):
-                        ti.atomic_add(tile_point_grad_color[idx_point_offset_with_sort_key_in_block, i], point_grad_color[i])
-                    ti.atomic_add(tile_point_grad_alpha[idx_point_offset_with_sort_key_in_block], gaussian_point_3d_alpha_grad)
-                    ti.atomic_add(tile_point_num_affected_pixels[idx_point_offset_with_sort_key_in_block], 1)
+                        ti.atomic_add(
+                            tile_point_grad_color[idx_point_offset_with_sort_key_in_block, i], point_grad_color[i])
+                    ti.atomic_add(
+                        tile_point_grad_alpha[idx_point_offset_with_sort_key_in_block], gaussian_point_3d_alpha_grad)
+                    ti.atomic_add(
+                        tile_point_num_affected_pixels[idx_point_offset_with_sort_key_in_block], 1)
             # end of the 256 block loop
             ti.simt.block.sync()
             # if the thread load the point, then it shall save the gradient of the point
@@ -835,21 +827,30 @@ def gaussian_point_rasterisation_backward(
                 to_save_point_id = point_id_in_camera_list[to_save_point_offset]
                 for i in ti.static(range(2)):
                     # no further process needed for abs grad, so directly save to global memory
-                    ti.atomic_add(grad_uv[to_save_point_id, i], tile_point_grad_uv[thread_id, i])
-                    ti.atomic_add(magnitude_grad_uv[to_save_point_id, i], tile_point_abs_grad_uv[thread_id, i])
+                    ti.atomic_add(grad_uv[to_save_point_id, i],
+                                  tile_point_grad_uv[thread_id, i])
+                    ti.atomic_add(
+                        magnitude_grad_uv[to_save_point_id, i], tile_point_abs_grad_uv[thread_id, i])
                 for i in ti.static(range(2)):
                     for j in ti.static(range(2)):
-                        ti.atomic_add(in_camera_grad_uv_cov_buffer[to_save_point_offset, i, j], tile_point_grad_uv_cov[thread_id, i, j])
+                        ti.atomic_add(
+                            in_camera_grad_uv_cov_buffer[to_save_point_offset, i, j], tile_point_grad_uv_cov[thread_id, i, j])
                 for i in ti.static(range(3)):
-                    ti.atomic_add(in_camera_grad_color_buffer[to_save_point_offset, i], tile_point_grad_color[thread_id, i])
+                    ti.atomic_add(
+                        in_camera_grad_color_buffer[to_save_point_offset, i], tile_point_grad_color[thread_id, i])
                 # no further process needed for alpha grad, so directly save to global memory
-                ti.atomic_add(grad_pointcloud_features[to_save_point_id, 7], tile_point_grad_alpha[thread_id])
+                ti.atomic_add(
+                    grad_pointcloud_features[to_save_point_id, 7], tile_point_grad_alpha[thread_id])
                 # no further process needed for num_affected_pixels, so directly save to global memory
-                ti.atomic_add(in_camera_num_affected_pixels[to_save_point_offset], tile_point_num_affected_pixels[thread_id])
-            ti.simt.block.sync() # sync the block, so that the next block can read the data into shared memory without issue
-        # end of the backward traversal loop, from last point to first point                    
-        magnitude_grad_viewspace_on_image[pixel_v, pixel_u, 0] = total_magnitude_grad_viewspace_on_image[0]
-        magnitude_grad_viewspace_on_image[pixel_v, pixel_u, 1] = total_magnitude_grad_viewspace_on_image[1]
+                ti.atomic_add(
+                    in_camera_num_affected_pixels[to_save_point_offset], tile_point_num_affected_pixels[thread_id])
+            # sync the block, so that the next block can read the data into shared memory without issue
+            ti.simt.block.sync()
+        # end of the backward traversal loop, from last point to first point
+        magnitude_grad_viewspace_on_image[pixel_v, pixel_u,
+                                          0] = total_magnitude_grad_viewspace_on_image[0]
+        magnitude_grad_viewspace_on_image[pixel_v, pixel_u,
+                                          1] = total_magnitude_grad_viewspace_on_image[1]
     # end of per pixel loop
 
     # one more loop to compute the gradient from viewspace to 3D point
@@ -859,7 +860,8 @@ def gaussian_point_rasterisation_backward(
             pointcloud=pointcloud,
             pointcloud_features=pointcloud_features,
             point_id=point_id)
-        point_grad_uv = ti.math.vec2(grad_uv[point_id, 0], grad_uv[point_id, 1])
+        point_grad_uv = ti.math.vec2(
+            grad_uv[point_id, 0], grad_uv[point_id, 1])
         point_grad_uv_cov_flat = ti.math.vec4(
             in_camera_grad_uv_cov_buffer[idx, 0, 0],
             in_camera_grad_uv_cov_buffer[idx, 0, 1],
@@ -871,6 +873,18 @@ def gaussian_point_rasterisation_backward(
             in_camera_grad_color_buffer[idx, 1],
             in_camera_grad_color_buffer[idx, 2],
         )
+        point_q_camera_pointcloud = ti.Vector(
+            [q_camera_pointcloud[point_object_id[point_id], idx] for idx in ti.static(range(4))])
+        point_t_camera_pointcloud = ti.Vector(
+            [t_camera_pointcloud[point_object_id[point_id], idx] for idx in ti.static(range(3))])
+        T_camera_pointcloud_mat = tranform_matrix_from_quaternion_and_translation(
+            q=point_q_camera_pointcloud,
+            t=point_t_camera_pointcloud,
+        )
+        T_pointcloud_camera = taichi_inverse_se3(
+            T_camera_pointcloud_mat)
+        ray_origin = ti.math.vec3(
+            [T_pointcloud_camera[0, 3], T_pointcloud_camera[1, 3], T_pointcloud_camera[2, 3]])
         uv, translation_camera = gaussian_point_3d.project_to_camera_position(
             T_camera_world=T_camera_pointcloud_mat,
             projective_transform=camera_intrinsics_mat,
@@ -892,6 +906,7 @@ def gaussian_point_rasterisation_backward(
             projective_transform=camera_intrinsics_mat,
             translation_camera=translation_camera,
         )
+        
         ray_direction = gaussian_point_3d.translation - ray_origin
         _, r_jacobian, g_jacobian, b_jacobian = gaussian_point_3d.get_color_with_jacobian_by_ray(
             ray_origin=ray_origin,
@@ -933,13 +948,17 @@ class GaussianPointCloudRasterisation(torch.nn.Module):
     class GaussianPointCloudRasterisationInput:
         point_cloud: torch.Tensor  # Nx3
         point_cloud_features: torch.Tensor  # NxM
+        # (N,), we allow points belong to different objects, 
+        # different objects may have different camera poses. 
+        # By moving camera, we can actually handle moving rigid objects.
+        # if no moving objects, then everything belongs to the same object with id 0.
+        # it shall works better once we also optimize for camera pose.
+        point_object_id: torch.Tensor  
         point_invalid_mask: torch.Tensor  # N
         camera_info: CameraInfo
-        T_pointcloud_camera: torch.Tensor  # 4x4 x to the right, y down, z forward
+        q_pointcloud_camera: torch.Tensor  # Kx4, x to the right, y down, z forward, K is the number of objects
+        t_pointcloud_camera: torch.Tensor  # Kx3, x to the right, y down, z forward, K is the number of objects
         color_max_sh_band: int = 2
-        point_extra_translation: Optional[torch.Tensor] = None  # Nx3
-        point_extra_rotation: Optional[torch.Tensor] = None  # Nx4
-        point_extra_scale: Optional[torch.Tensor] = None  # Nx3
 
     @dataclass
     class BackwardValidPointHookInput:
@@ -967,27 +986,29 @@ class GaussianPointCloudRasterisation(torch.nn.Module):
 
             @staticmethod
             @custom_fwd(cast_inputs=torch_type)
-            def forward(ctx, 
-                        pointcloud, 
-                        pointcloud_features, 
-                        point_invalid_mask, 
-                        T_pointcloud_camera, 
-                        camera_info, 
+            def forward(ctx,
+                        pointcloud,
+                        pointcloud_features,
+                        point_invalid_mask,
+                        point_object_id,
+                        q_pointcloud_camera,
+                        t_pointcloud_camera,
+                        camera_info,
                         color_max_sh_band,
-                        point_extra_translation=None,
-                        point_extra_rotation=None,
-                        point_extra_scale=None,
-            ):
+                        ):
                 point_in_camera_mask = torch.zeros(
                     size=(pointcloud.shape[0],), dtype=torch.int8, device=pointcloud.device)
                 point_id = torch.arange(
                     pointcloud.shape[0], dtype=torch.int32, device=pointcloud.device)
-                T_camera_pointcloud = inverse_se3(T_pointcloud_camera)
+                q_camera_pointcloud, t_camera_pointcloud = inverse_se3_qt_torch(
+                    q=q_pointcloud_camera, t=t_pointcloud_camera)
                 filter_point_in_camera(
                     pointcloud=pointcloud,
                     point_invalid_mask=point_invalid_mask,
+                    point_object_id=point_object_id,
                     camera_intrinsics=camera_info.camera_intrinsics,
-                    T_camera_pointcloud=T_camera_pointcloud,
+                    q_camera_pointcloud=q_camera_pointcloud,
+                    t_camera_pointcloud=t_camera_pointcloud,
                     point_in_camera_mask=point_in_camera_mask,
                     near_plane=self.config.near_plane,
                     far_plane=self.config.far_plane,
@@ -995,7 +1016,8 @@ class GaussianPointCloudRasterisation(torch.nn.Module):
                     camera_width=camera_info.camera_width,
                 )
                 point_in_camera_mask = point_in_camera_mask.bool()
-                point_id_in_camera_list = point_id[point_in_camera_mask].contiguous()
+                point_id_in_camera_list = point_id[point_in_camera_mask].contiguous(
+                )
                 del point_id
                 del point_in_camera_mask
 
@@ -1012,30 +1034,19 @@ class GaussianPointCloudRasterisation(torch.nn.Module):
                 point_color = torch.zeros(
                     size=(num_points_in_camera, 3), dtype=torch.float32, device=pointcloud.device)
 
-                has_extra_rotation_and_scale = (point_extra_rotation is not None) and (
-                    point_extra_scale is not None) and (point_extra_translation is not None)
-                point_extra_rotation = torch.empty(
-                    size=(0, 4), dtype=torch.float32, device=pointcloud.device) if point_extra_rotation is None else point_extra_rotation
-                point_extra_translation = torch.empty(
-                    size=(0, 3), dtype=torch.float32, device=pointcloud.device) if point_extra_translation is None else point_extra_translation
-                point_extra_scale = torch.empty(
-                    size=(0, 3), dtype=torch.float32, device=pointcloud.device) if point_extra_scale is None else point_extra_scale
-
                 generate_point_attributes_in_camera_plane(
                     pointcloud=pointcloud,
                     pointcloud_features=pointcloud_features,
+                    point_object_id=point_object_id,
                     camera_intrinsics=camera_info.camera_intrinsics,
-                    T_camera_pointcloud=T_camera_pointcloud,
                     point_id_list=point_id_in_camera_list,
+                    q_camera_pointcloud=q_camera_pointcloud,
+                    t_camera_pointcloud=t_camera_pointcloud,
                     point_uv=point_uv,
                     point_in_camera=point_in_camera,
                     point_uv_covariance=point_uv_covariance,
                     point_alpha_after_activation=point_alpha_after_activation,
                     point_color=point_color,
-                    has_extra_rotation_and_scale=has_extra_rotation_and_scale,
-                    point_extra_translation=point_extra_translation,
-                    point_extra_rotation=point_extra_rotation,
-                    point_extra_scale=point_extra_scale,
                 )
 
                 num_overlap_tiles = torch.empty_like(point_id_in_camera_list)
@@ -1054,7 +1065,7 @@ class GaussianPointCloudRasterisation(torch.nn.Module):
                 else:
                     total_num_overlap_tiles = 0
                 accumulated_num_overlap_tiles = torch.cat(
-                    (torch.zeros(size=(1,), dtype=torch.int32, device=pointcloud.device), 
+                    (torch.zeros(size=(1,), dtype=torch.int32, device=pointcloud.device),
                      accumulated_num_overlap_tiles[:-1]))
                 # del num_overlap_tiles
                 point_in_camera_sort_key = torch.empty(
@@ -1103,7 +1114,6 @@ class GaussianPointCloudRasterisation(torch.nn.Module):
                     camera_info.camera_height, camera_info.camera_width, dtype=torch.int32, device=pointcloud.device)
                 pixel_valid_point_count = torch.empty(
                     camera_info.camera_height, camera_info.camera_width, dtype=torch.int32, device=pointcloud.device)
-                
 
                 if point_in_camera_sort_key.shape[0] > 0:
                     gaussian_point_rasterisation(
@@ -1127,15 +1137,19 @@ class GaussianPointCloudRasterisation(torch.nn.Module):
                 ctx.save_for_backward(
                     pointcloud,
                     pointcloud_features,
-                    point_offset_with_sort_key, # point_id_with_sort_key is sorted by tile and depth and has duplicated points, e.g. one points is belong to multiple tiles
-                    point_id_in_camera_list, # point_in_camera_id does not have duplicated points
+                    # point_id_with_sort_key is sorted by tile and depth and has duplicated points, e.g. one points is belong to multiple tiles
+                    point_offset_with_sort_key,
+                    point_id_in_camera_list,  # point_in_camera_id does not have duplicated points
                     tile_points_start,
                     tile_points_end,
                     pixel_accumulated_alpha,
                     pixel_offset_of_last_effective_point,
-                    T_pointcloud_camera,
-                    T_camera_pointcloud,
-                    num_overlap_tiles
+                    num_overlap_tiles,
+                    point_object_id,
+                    q_pointcloud_camera,
+                    q_camera_pointcloud,
+                    t_pointcloud_camera,
+                    t_camera_pointcloud
                 )
                 ctx.camera_info = camera_info
                 ctx.color_max_sh_band = color_max_sh_band
@@ -1145,23 +1159,36 @@ class GaussianPointCloudRasterisation(torch.nn.Module):
             @staticmethod
             @custom_bwd
             def backward(ctx, grad_rasterized_image, grad_rasterized_depth, grad_pixel_valid_point_count):
-                grad_pointcloud = grad_pointcloud_features = grad_T_pointcloud_camera = None
+                grad_pointcloud = grad_pointcloud_features = grad_q_pointcloud_camera = grad_t_pointcloud_camera = None
                 if ctx.needs_input_grad[0] or ctx.needs_input_grad[1]:
-                    pointcloud, pointcloud_features, point_offset_with_sort_key, point_id_in_camera_list, tile_points_start, tile_points_end, pixel_accumulated_alpha, pixel_offset_of_last_effective_point, T_pointcloud_camera, T_camera_pointcloud, num_overlap_tiles = ctx.saved_tensors
+                    pointcloud, \
+                        pointcloud_features, \
+                        point_offset_with_sort_key, \
+                        point_id_in_camera_list, \
+                        tile_points_start, \
+                        tile_points_end, \
+                        pixel_accumulated_alpha, \
+                        pixel_offset_of_last_effective_point, \
+                        num_overlap_tiles, \
+                        point_object_id, \
+                        q_pointcloud_camera, \
+                        q_camera_pointcloud, \
+                        t_pointcloud_camera, \
+                        t_camera_pointcloud = ctx.saved_tensors
                     camera_info = ctx.camera_info
                     color_max_sh_band = ctx.color_max_sh_band
                     grad_rasterized_image = grad_rasterized_image.contiguous()
                     grad_pointcloud = torch.zeros_like(pointcloud)
                     grad_pointcloud_features = torch.zeros_like(
                         pointcloud_features)
-                    
+
                     grad_viewspace = torch.zeros(
                         size=(pointcloud.shape[0], 2), dtype=torch.float32, device=pointcloud.device)
                     magnitude_grad_viewspace = torch.zeros(
                         size=(pointcloud.shape[0], 2), dtype=torch.float32, device=pointcloud.device)
                     magnitude_grad_viewspace_on_image = torch.empty_like(
                         grad_rasterized_image[:, :, :2])
-                    
+
                     in_camera_grad_uv_cov_buffer = torch.zeros(
                         size=(point_id_in_camera_list.shape[0], 2, 2), dtype=torch.float32, device=pointcloud.device)
                     in_camera_grad_color_buffer = torch.zeros(
@@ -1172,12 +1199,14 @@ class GaussianPointCloudRasterisation(torch.nn.Module):
                         size=(point_id_in_camera_list.shape[0], 2), dtype=torch.float32, device=pointcloud.device)
                     in_camera_num_affected_pixels = torch.zeros(
                         size=(point_id_in_camera_list.shape[0],), dtype=torch.int32, device=pointcloud.device)
-                    
+
                     gaussian_point_rasterisation_backward(
                         camera_height=camera_info.camera_height,
                         camera_width=camera_info.camera_width,
                         camera_intrinsics=camera_info.camera_intrinsics,
-                        T_camera_pointcloud=T_camera_pointcloud,
+                        point_object_id=point_object_id,
+                        q_camera_pointcloud=q_camera_pointcloud,
+                        t_camera_pointcloud=t_camera_pointcloud,
                         pointcloud=pointcloud,
                         pointcloud_features=pointcloud_features,
                         tile_points_start=tile_points_start,
@@ -1202,16 +1231,21 @@ class GaussianPointCloudRasterisation(torch.nn.Module):
                     grad_pointcloud_features = self._clear_grad_by_color_max_sh_band(
                         grad_pointcloud_features=grad_pointcloud_features,
                         color_max_sh_band=color_max_sh_band)
-                    grad_pointcloud_features[:, :4] *= self.config.grad_q_factor
-                    grad_pointcloud_features[:, 4:7] *= self.config.grad_s_factor
-                    grad_pointcloud_features[:, 7] *= self.config.grad_alpha_factor
-                    grad_pointcloud_features[:, 8:] *= self.config.grad_color_factor
-                    
+                    grad_pointcloud_features[:,
+                                             :4] *= self.config.grad_q_factor
+                    grad_pointcloud_features[:,
+                                             4:7] *= self.config.grad_s_factor
+                    grad_pointcloud_features[:,
+                                             7] *= self.config.grad_alpha_factor
+                    grad_pointcloud_features[:,
+                                             8:] *= self.config.grad_color_factor
+
                     if backward_valid_point_hook is not None:
                         backward_valid_point_hook_input = GaussianPointCloudRasterisation.BackwardValidPointHookInput(
                             point_id_in_camera_list=point_id_in_camera_list,
                             grad_point_in_camera=grad_pointcloud[point_id_in_camera_list],
-                            grad_pointfeatures_in_camera=grad_pointcloud_features[point_id_in_camera_list],
+                            grad_pointfeatures_in_camera=grad_pointcloud_features[
+                                point_id_in_camera_list],
                             grad_viewspace=grad_viewspace[point_id_in_camera_list],
                             magnitude_grad_viewspace=magnitude_grad_viewspace[point_id_in_camera_list],
                             magnitude_grad_viewspace_on_image=magnitude_grad_viewspace_on_image,
@@ -1222,9 +1256,27 @@ class GaussianPointCloudRasterisation(torch.nn.Module):
                         )
                         backward_valid_point_hook(
                             backward_valid_point_hook_input)
-                    
-                    
-                return grad_pointcloud, grad_pointcloud_features, None, grad_T_pointcloud_camera, None, None, None, None, None
+                """_summary_
+                pointcloud,
+                        pointcloud_features,
+                        point_invalid_mask,
+                        point_object_id,
+                        q_pointcloud_camera,
+                        t_pointcloud_camera,
+                        camera_info,
+                        color_max_sh_band,
+
+                Returns:
+                    _type_: _description_
+                """
+
+                return grad_pointcloud, \
+                    grad_pointcloud_features, \
+                    None, \
+                    None, \
+                    grad_q_pointcloud_camera, \
+                    grad_t_pointcloud_camera, \
+                    None, None
 
         self._module_function = _module_function
 
@@ -1249,21 +1301,20 @@ class GaussianPointCloudRasterisation(torch.nn.Module):
         pointcloud = input_data.point_cloud
         pointcloud_features = input_data.point_cloud_features
         point_invalid_mask = input_data.point_invalid_mask
-        T_pointcloud_camera = input_data.T_pointcloud_camera
+        point_object_id = input_data.point_object_id
+        q_pointcloud_camera = input_data.q_pointcloud_camera
+        t_pointcloud_camera = input_data.t_pointcloud_camera
         color_max_sh_band = input_data.color_max_sh_band
         camera_info = input_data.camera_info
-        point_extra_translation = input_data.point_extra_translation
-        point_extra_rotation = input_data.point_extra_rotation
-        point_extra_scale = input_data.point_extra_scale
         assert camera_info.camera_width % 16 == 0
         assert camera_info.camera_height % 16 == 0
         return self._module_function.apply(
             pointcloud,
             pointcloud_features,
             point_invalid_mask,
-            T_pointcloud_camera,
+            point_object_id,
+            q_pointcloud_camera,
+            t_pointcloud_camera,
             camera_info,
             color_max_sh_band,
-            point_extra_translation,
-            point_extra_rotation,
-            point_extra_scale)
+        )

--- a/taichi_3d_gaussian_splatting/GaussianPointCloudScene.py
+++ b/taichi_3d_gaussian_splatting/GaussianPointCloudScene.py
@@ -58,6 +58,10 @@ class GaussianPointCloudScene(torch.nn.Module):
             "point_invalid_mask",
             torch.zeros(self.point_cloud.shape[0], dtype=torch.int8)
         )
+        self.register_buffer(
+            "point_object_id",
+            torch.zeros(self.point_cloud.shape[0], dtype=torch.int32)
+        )
         if config.max_num_points_ratio is not None:
             self.point_invalid_mask[num_points:] = 1
 

--- a/taichi_3d_gaussian_splatting/ImagePoseDataset.py
+++ b/taichi_3d_gaussian_splatting/ImagePoseDataset.py
@@ -7,6 +7,7 @@ import torchvision
 import torchvision.transforms as transforms
 from .Camera import CameraInfo
 from typing import Any
+from .utils import se3_to_quaternion_and_translation_torch
 
 
 class ImagePoseDataset(torch.utils.data.Dataset):
@@ -38,6 +39,8 @@ class ImagePoseDataset(torch.utils.data.Dataset):
         image_path = self.df.iloc[idx]["image_path"]
         T_pointcloud_camera = self._pandas_field_to_tensor(
             self.df.iloc[idx]["T_pointcloud_camera"])
+        q_pointcloud_camera, t_pointcloud_camera = se3_to_quaternion_and_translation_torch(
+            T_pointcloud_camera.unsqueeze(0))
         camera_intrinsics = self._pandas_field_to_tensor(
             self.df.iloc[idx]["camera_intrinsics"])
         camera_height = self.df.iloc[idx]["camera_height"]
@@ -56,4 +59,4 @@ class ImagePoseDataset(torch.utils.data.Dataset):
             camera_width=camera_width,
             camera_id=camera_id,
         )
-        return image, T_pointcloud_camera, camera_info
+        return image, q_pointcloud_camera ,t_pointcloud_camera, camera_info

--- a/taichi_3d_gaussian_splatting/utils.py
+++ b/taichi_3d_gaussian_splatting/utils.py
@@ -334,6 +334,93 @@ def inverse_se3(transform: torch.Tensor):
     inverse_transform[3, 3] = 1
     return inverse_transform
 
+def quaternion_conjugate_torch(
+    q: torch.Tensor, # (batch_size, 4), (x, y, z, w)
+):
+    return torch.cat([-q[..., 0:3], q[..., 3:4]], dim=-1)
+
+def quaternion_multiply_torch(
+    q0: torch.Tensor, # (batch_size, 4)
+    q1: torch.Tensor, # (batch_size, 4)
+):
+    x0, y0, z0, w0 = q0[..., 0], q0[..., 1], q0[..., 2], q0[..., 3]
+    x1, y1, z1, w1 = q1[..., 0], q1[..., 1], q1[..., 2], q1[..., 3]
+    x = w0 * x1 + x0 * w1 + y0 * z1 - z0 * y1
+    y = w0 * y1 - x0 * z1 + y0 * w1 + z0 * x1
+    z = w0 * z1 + x0 * y1 - y0 * x1 + z0 * w1
+    w = w0 * w1 - x0 * x1 - y0 * y1 - z0 * z1
+    return torch.stack([x, y, z, w], dim=-1)
+
+def quaternion_rotate_torch(
+    q: torch.Tensor, # (batch_size, 4)
+    v: torch.Tensor, # (batch_size, 3)
+):
+    q = q / torch.norm(q, dim=-1, keepdim=True)
+    v = torch.cat([v, torch.zeros_like(v[..., :1])], dim=-1)
+    q_conj = quaternion_conjugate_torch(q)
+    return quaternion_multiply_torch(
+        quaternion_multiply_torch(q, v), q_conj)[..., :3]
+    
+
+def inverse_se3_qt_torch(
+    q: torch.Tensor, # (batch_size, 4)
+    t: torch.Tensor, # (batch_size, 3)
+)->Tuple[torch.Tensor, torch.Tensor]:
+    q_inv = quaternion_conjugate_torch(q)
+    t_inv = -quaternion_rotate_torch(q_inv, t)
+    return q_inv, t_inv
+
+def rotation_matrix_to_quaternion_torch(
+    R: torch.Tensor # (batch_size, 3, 3)
+)->torch.Tensor:
+    q = torch.zeros(R.shape[0], 4, device=R.device, dtype=R.dtype) # (batch_size, 4) x, y, z, w
+    trace = R[..., 0, 0] + R[..., 1, 1] + R[..., 2, 2]
+    q0_mask = trace > 0
+    q1_mask = (R[..., 0, 0] > R[..., 1, 1]) & (R[..., 0, 0] > R[..., 2, 2]) & ~q0_mask
+    q2_mask = (R[..., 1, 1] > R[..., 2, 2]) & ~q0_mask & ~q1_mask
+    q3_mask = ~q0_mask & ~q1_mask & ~q2_mask
+    if q0_mask.any():
+        R_for_q0 = R[q0_mask]
+        S_for_q0 = 0.5 / torch.sqrt(1 + trace[q0_mask])
+        q[q0_mask, 3] = 0.25 / S_for_q0
+        q[q0_mask, 0] = (R_for_q0[..., 2, 1] - R_for_q0[..., 1, 2]) * S_for_q0
+        q[q0_mask, 1] = (R_for_q0[..., 0, 2] - R_for_q0[..., 2, 0]) * S_for_q0
+        q[q0_mask, 2] = (R_for_q0[..., 1, 0] - R_for_q0[..., 0, 1]) * S_for_q0
+    
+    if q1_mask.any():
+        R_for_q1 = R[q1_mask]
+        S_for_q1 = 2.0 * torch.sqrt(1 + R_for_q1[..., 0, 0] - R_for_q1[..., 1, 1] - R_for_q1[..., 2, 2])
+        q[q1_mask, 0] = 0.25 * S_for_q1
+        q[q1_mask, 1] = (R_for_q1[..., 0, 1] + R_for_q1[..., 1, 0]) / S_for_q1
+        q[q1_mask, 2] = (R_for_q1[..., 0, 2] + R_for_q1[..., 2, 0]) / S_for_q1
+        q[q1_mask, 3] = (R_for_q1[..., 2, 1] - R_for_q1[..., 1, 2]) / S_for_q1
+    
+    if q2_mask.any():
+        R_for_q2 = R[q2_mask]
+        S_for_q2 = 2.0 * torch.sqrt(1 + R_for_q2[..., 1, 1] - R_for_q2[..., 0, 0] - R_for_q2[..., 2, 2])
+        q[q2_mask, 0] = (R_for_q2[..., 0, 1] + R_for_q2[..., 1, 0]) / S_for_q2
+        q[q2_mask, 1] = 0.25 * S_for_q2
+        q[q2_mask, 2] = (R_for_q2[..., 1, 2] + R_for_q2[..., 2, 1]) / S_for_q2
+        q[q2_mask, 3] = (R_for_q2[..., 0, 2] - R_for_q2[..., 2, 0]) / S_for_q2
+    
+    if q3_mask.any():
+        R_for_q3 = R[q3_mask]
+        S_for_q3 = 2.0 * torch.sqrt(1 + R_for_q3[..., 2, 2] - R_for_q3[..., 0, 0] - R_for_q3[..., 1, 1])
+        q[q3_mask, 0] = (R_for_q3[..., 0, 2] + R_for_q3[..., 2, 0]) / S_for_q3
+        q[q3_mask, 1] = (R_for_q3[..., 1, 2] + R_for_q3[..., 2, 1]) / S_for_q3
+        q[q3_mask, 2] = 0.25 * S_for_q3
+        q[q3_mask, 3] = (R_for_q3[..., 1, 0] - R_for_q3[..., 0, 1]) / S_for_q3
+    return q
+    
+
+def se3_to_quaternion_and_translation_torch(
+    transform: torch.Tensor, # (batch_size, 4, 4)
+)->Tuple[torch.Tensor, torch.Tensor]:
+    R = transform[..., :3, :3]
+    t = transform[..., :3, 3]
+    q = rotation_matrix_to_quaternion_torch(R)
+    return q, t
+
 
 @ti.func
 def taichi_inverse_se3(transform: ti.math.mat4):


### PR DESCRIPTION
Switch camera pose from SE3 to quaternion, to simplify later pose optimization.
Also, a simple idea is to assign an object id to each point, take some 6DOF pose estimation for moving objects as input, then handle rigid objects as points with different camera poses (movement of the object is transformed into the movement of the camera). In this PR, we first change the input format for rasterization. Will try to support the whole feature in later PR.