### PR TITLE
Remove spurious comma in GaussianPointCloudScene.py

### DIFF
--- a/taichi_3d_gaussian_splatting/GaussianPointCloudScene.py
+++ b/taichi_3d_gaussian_splatting/GaussianPointCloudScene.py
@@ -13,7 +13,7 @@ class GaussianPointCloudScene(torch.nn.Module):
     @dataclass
     class PointCloudSceneConfig(YAMLWizard):
         num_of_features: int = 56
-        max_num_points_ratio: Optional[float] = None,
+        max_num_points_ratio: Optional[float] = None
         add_sphere: bool = False
         sphere_radius_factor: float = 4.0
         num_points_sphere: int = 10000


### PR DESCRIPTION
The comma makes it a tuple `(None, )` instead of just `None`. Then, it fails with:

```
In [3]: scene = GaussianPointCloudScene.from_parquet('/home/danlu/debug/gaussian-splatting-2/logs/scene_169000.parquet')
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[3], line 1
----> 1 scene = GaussianPointCloudScene.from_parquet('/home/danlu/debug/gaussian-splatting-2/logs/scene_169000.parquet')

File ~/builds/taichi_3d_gaussian_splatting/taichi_3d_gaussian_splatting/GaussianPointCloudScene.py:150, in GaussianPointCloudScene.from_parquet(path, config)
    147 else:
    148     valid_point_cloud_features = torch.from_numpy(
    149         scene_df[feature_columns].to_numpy())
--> 150     scene = GaussianPointCloudScene(
    151         point_cloud, config, point_cloud_features=valid_point_cloud_features)
    152 return scene

File ~/builds/taichi_3d_gaussian_splatting/taichi_3d_gaussian_splatting/GaussianPointCloudScene.py:42, in GaussianPointCloudScene.__init__(self, point_cloud, config, point_cloud_features)
     40 if config.max_num_points_ratio is not None:
     41     num_points = point_cloud.shape[0]
---> 42     max_num_points = int(num_points * config.max_num_points_ratio)
     43     assert max_num_points > num_points, "max_num_points_ratio should be greater than 1.0"
     44     point_cloud = torch.cat(
     45         [point_cloud, torch.zeros((max_num_points - num_points, 3))], dim=0)

TypeError: int() argument must be a string, a bytes-like object or a number, not 'tuple'
```